### PR TITLE
feat: add keymap to switch keyboard layout in Hyprland

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -50,7 +50,7 @@ exec-once = $notification
 
 # For all categories, see https://wiki.hyprland.org/Configuring/Variables/
 input {
-    kb_layout = fr
+    kb_layout = fr,us
     kb_variant =
     kb_model =
     kb_options =

--- a/hypr/keybinds.conf
+++ b/hypr/keybinds.conf
@@ -9,6 +9,7 @@ bind = CONTROL $mainMod, p, exec, ~/src/Hyprshot/hyprshot -m region -z
 bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod, t, togglesplit, # dwindle
 bind = $mainMod, return, fullscreen
+bind = $mainMod, CAPS_LOCK, switchxkblayout
 bind = CONTROL $mainMod, t, exec, $terminal
 bind = $mainMod, KP_Enter, exec, pkill mate-calc || mate-calc
 bind = CONTROL , space, exec, pkill $menu || $menu $menu_options


### PR DESCRIPTION
This commit introduces a keybinding to switch between French (fr) and US (us) keyboard layouts in Hyprland.

Changes:
- Modified `hypr/hyprland.conf` to include `us` in the `input.kb_layout` setting, changing it from `fr` to `fr,us`.
- Modified `hypr/keybinds.conf` to add a new keybinding `ALT + CAPS_LOCK` (represented as `$mainMod, CAPS_LOCK`) that executes `switchxkblayout` to cycle through the configured keyboard layouts.